### PR TITLE
Improve FTP handling and add reset tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,23 @@ This contains everything you need to run your app locally.
 3. Run the app:
    `npm run dev`
 
+## Backend / PostgreSQL
+
+The accompanying `server.js` process stores data in a PostgreSQL database.
+Configure the connection using the `DB_HOST`, `DB_NAME`, `DB_USER` and
+`DB_PASS` environment variables or via the **Editar Credenciales** dialog in the
+UI. FTP uploads use `FTP_HOST`, `FTP_PORT`, `FTP_USER` and `FTP_PASS`, which can
+also be set from the **Configurar FTP** dialog. When deploying on platforms such
+as Netlify you must run this Node server separately.
+
 ## Reset Data
 
 If you need to wipe all stored data and logs, open the **Control Panel** screen
 and use the **Factory Reset** button. This will clear all local tables, remove
-logs and attempt to delete the same data on the remote server.
+logs and attempt to delete the same data on the remote server. To allow
+re-importing files that were previously uploaded, use the **Reiniciar Cache**
+button found in the same section.
+
+## Versioning
+
+Cada vez que se realice un cambio en el código se debe incrementar el número **build** en [`version.ts`](version.ts). Una vez que las funcionalidades estén confirmadas se actualizará el número de versión siguiendo indicaciones del responsable.

--- a/components/ControlPanelView.tsx
+++ b/components/ControlPanelView.tsx
@@ -125,10 +125,22 @@ export const ControlPanelView: React.FC = () => {
                     </pre>
                 </div>
             </div>
-            
+
             <div className="border-t-2 border-red-500/30 pt-6 space-y-4">
                 <h3 className="text-xl font-bold text-red-400">Zona de Peligro</h3>
-                 <div className="bg-red-600/10 p-4 rounded-md flex flex-col sm:flex-row justify-between items-center gap-4">
+                <div className="bg-red-600/10 p-4 rounded-md flex flex-col sm:flex-row justify-between items-center gap-4">
+                    <div>
+                        <h4 className="font-semibold text-red-400">Reiniciar Cache de Importación</h4>
+                        <p className="text-sm text-brand-text-secondary mt-1">Elimina el historial de archivos importados para permitir subirlos nuevamente.</p>
+                    </div>
+                    <button
+                        onClick={async () => { await db.clearTable('processed_files_hashes'); addLog('✅ Cache de importación reiniciada.'); }}
+                        className="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-colors flex-shrink-0"
+                    >
+                        Reiniciar Cache
+                    </button>
+                </div>
+                <div className="bg-red-600/10 p-4 rounded-md flex flex-col sm:flex-row justify-between items-center gap-4">
                     <div>
                         <h4 className="font-semibold text-red-400">Factory Reset</h4>
                         <p className="text-sm text-brand-text-secondary mt-1">

--- a/components/FtpCredentialsModal.tsx
+++ b/components/FtpCredentialsModal.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useEffect } from 'react';
+import { Modal } from './Modal';
+
+interface FtpCreds {
+    host: string;
+    port: string;
+    user: string;
+    password: string;
+}
+
+interface Props {
+    isOpen: boolean;
+    onClose: () => void;
+    onSave: (c: FtpCreds) => void;
+}
+
+export const FtpCredentialsModal: React.FC<Props> = ({ isOpen, onClose, onSave }) => {
+    const [host, setHost] = useState('');
+    const [port, setPort] = useState('21');
+    const [user, setUser] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+
+    useEffect(() => {
+        if (isOpen) {
+            setError('');
+            fetch('/api/get-ftp-credentials')
+                .then(r => r.json())
+                .then(c => {
+                    if (c.host) {
+                        setHost(c.host);
+                        setPort(String(c.port || '21'));
+                        setUser(c.user || '');
+                    }
+                })
+                .catch(() => setError('No se pudieron cargar las credenciales actuales'));
+        }
+    }, [isOpen]);
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        onSave({ host, port, user, password });
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose}>
+            <div className="bg-brand-surface rounded-lg shadow-xl p-6 w-full max-w-md">
+                <h2 className="text-xl font-bold mb-4">Credenciales FTP</h2>
+                <form onSubmit={handleSubmit} className="space-y-4">
+                    {error && (
+                        <p className="text-sm text-red-400 text-center">{error}</p>
+                    )}
+                    <input type="text" placeholder="Host" value={host} onChange={e => setHost(e.target.value)} className="w-full bg-brand-bg border border-brand-border rounded-md p-2" required />
+                    <input type="text" placeholder="Puerto" value={port} onChange={e => setPort(e.target.value)} className="w-full bg-brand-bg border border-brand-border rounded-md p-2" required />
+                    <input type="text" placeholder="Usuario" value={user} onChange={e => setUser(e.target.value)} className="w-full bg-brand-bg border border-brand-border rounded-md p-2" required />
+                    <input type="password" placeholder="Contraseña" value={password} onChange={e => setPassword(e.target.value)} className="w-full bg-brand-bg border border-brand-border rounded-md p-2" required />
+                    <div className="flex justify-end gap-4 pt-2">
+                        <button type="button" onClick={onClose} className="bg-brand-border text-brand-text px-4 py-2 rounded-lg">Cancelar</button>
+                        <button type="submit" className="bg-brand-primary hover:bg-brand-primary-hover text-white px-4 py-2 rounded-lg">Guardar</button>
+                    </div>
+                </form>
+            </div>
+        </Modal>
+    );
+};

--- a/components/LoginView.tsx
+++ b/components/LoginView.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { DbCredentialsModal } from './DbCredentialsModal';
+import { FtpCredentialsModal } from './FtpCredentialsModal';
 
 import { APP_VERSION, APP_BUILD } from '../version';
 
@@ -18,6 +19,9 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
     const [dbConnected, setDbConnected] = useState<boolean | null>(null);
     const [dbError, setDbError] = useState('');
     const [showCreds, setShowCreds] = useState(false);
+    const [showFtpCreds, setShowFtpCreds] = useState(false);
+    const [ftpConnected, setFtpConnected] = useState<boolean | null>(null);
+    const [ftpError, setFtpError] = useState('');
 
     useEffect(() => {
         fetch('/api/server-ip')
@@ -37,6 +41,21 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
         } catch (e) {
             setDbConnected(false);
             setDbError('No se pudo conectar con la API.');
+        }
+
+        try {
+            const res = await fetch('/api/test-ftp');
+            if (res.ok) {
+                setFtpConnected(true);
+                setFtpError('');
+            } else {
+                const d = await res.json();
+                setFtpConnected(false);
+                setFtpError(d.error || 'Error');
+            }
+        } catch (e) {
+            setFtpConnected(false);
+            setFtpError('No se pudo conectar al FTP.');
         }
     };
 
@@ -63,6 +82,27 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
         }
     };
 
+    const updateFtpCreds = async (c: { host: string; port: string; user: string; password: string }) => {
+        try {
+            await fetch('/api/set-ftp-credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(c)
+            });
+            const res = await fetch('/api/test-ftp');
+            if (res.ok) {
+                setFtpConnected(true);
+                setFtpError('');
+            } else {
+                const d = await res.json();
+                setFtpConnected(false);
+                setFtpError(d.error || 'Error');
+            }
+        } finally {
+            setShowFtpCreds(false);
+        }
+    };
+
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         setError('');
@@ -83,6 +123,7 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
     return (
         <div className="flex items-center justify-center min-h-screen">
             <DbCredentialsModal isOpen={showCreds} onClose={() => setShowCreds(false)} onSave={updateCreds} />
+            <FtpCredentialsModal isOpen={showFtpCreds} onClose={() => setShowFtpCreds(false)} onSave={updateFtpCreds} />
             <div className="w-full max-w-sm mx-auto bg-brand-surface rounded-lg p-8 shadow-2xl animate-fade-in">
                 <div className="text-center mb-4">
                     <h1 className="text-3xl font-bold text-brand-text">Bienvenido</h1>
@@ -96,10 +137,15 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
                             <div className="mt-1 flex gap-2 justify-center">
                                 <button type="button" onClick={checkStatus} className="underline">Reintentar</button>
                                 <button type="button" onClick={() => setShowCreds(true)} className="underline">Editar credenciales</button>
+                                <button type="button" onClick={() => setShowFtpCreds(true)} className="underline">Configurar FTP</button>
                             </div>
                         </div>
                     )}
                     {dbConnected && <p className="text-xs text-green-500 mt-2">DB conectada</p>}
+                    {ftpConnected === false && (
+                        <div className="text-red-400 text-xs mt-2">Error FTP: {ftpError}</div>
+                    )}
+                    {ftpConnected && <p className="text-xs text-green-500 mt-1">FTP conectado</p>}
                 </div>
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <div>
@@ -130,6 +176,9 @@ export const LoginView: React.FC<LoginViewProps> = ({ onLogin }) => {
                     <div>
                         <button type="submit" className="w-full bg-brand-primary hover:bg-brand-primary-hover text-white font-bold py-3 px-4 rounded-lg shadow-md transition-colors disabled:opacity-50">
                             Iniciar Sesión
+                        </button>
+                        <button type="button" onClick={() => setShowFtpCreds(true)} className="w-full mt-2 text-xs underline text-brand-text-secondary">
+                            Configurar FTP
                         </button>
                     </div>
                 </form>

--- a/components/PerformanceView.tsx
+++ b/components/PerformanceView.tsx
@@ -459,6 +459,10 @@ export const PerformanceView: React.FC<PerformanceViewProps> = ({ clients, getPe
     const handleVideoSave = async (adName: string, videoFile: File) => {
         if (!selectedClient) return;
         try {
+            const form = new FormData();
+            form.append('file', videoFile);
+            const res = await fetch('/api/upload', { method: 'POST', body: form });
+            if (!res.ok) throw new Error('Error al subir archivo');
             const dataUrl = await fileToBase64(videoFile);
             const newVideo: UploadedVideo = { id: `${selectedClient.id}_${adName}`, clientId: selectedClient.id, adName: adName, videoFileName: videoFile.name, dataUrl: dataUrl };
             const updatedVideos = [...uploadedVideos.filter(v => v.id !== newVideo.id), newVideo];

--- a/database.ts
+++ b/database.ts
@@ -170,8 +170,7 @@ const db = {
 
         if (dbConnectionStatus.connected) {
             try {
-                const res = await fetch(`${API_BASE}/kv/clients`, { method: 'DELETE' });
-                // ignore result
+                await fetch(`${API_BASE}/factory-reset`, { method: 'POST' });
             } catch {}
         }
 

--- a/lib/ftpClient.ts
+++ b/lib/ftpClient.ts
@@ -13,6 +13,21 @@ export function setFtpCredentials(creds: FtpCredentials) {
     credentials = creds;
 }
 
+export async function checkFtpConnection(): Promise<void> {
+    if (!credentials) throw new Error('FTP credentials not configured');
+    const client = new Client();
+    try {
+        await client.access({
+            host: credentials.host,
+            port: credentials.port,
+            user: credentials.user,
+            password: credentials.password,
+        });
+    } finally {
+        client.close();
+    }
+}
+
 export async function uploadFile(localPath: string, remotePath: string): Promise<void> {
     if (!credentials) throw new Error('FTP credentials not configured');
 

--- a/version.ts
+++ b/version.ts
@@ -1,2 +1,2 @@
 export const APP_VERSION = '0.0.1';
-export const APP_BUILD = 1;
+export const APP_BUILD = 4;


### PR DESCRIPTION
## Summary
- load current FTP credentials when opening the config modal
- test FTP connection after saving and display errors in Login and DB views
- expose FTP test and read endpoints in server
- allow clearing import cache from Control Panel
- document build increments and bump build number
- add server endpoint for factory reset and call it from database helper
- **document PostgreSQL setup and bump build number**

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find JSX namespace and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688c1fbce22c833281033ce13de45dbd