### PR TITLE
Disable login screen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,10 @@
 GEMINI_API_KEY=
 
 # PostgreSQL connection settings
-DB_HOST=
-DB_NAME=
-DB_USER=
-DB_PASS=
+DB_HOST=localhost
+DB_NAME=my_database
+DB_USER=my_user
+DB_PASS=my_password
 
 # FTP credentials (optional)
 FTP_HOST=

--- a/App.tsx
+++ b/App.tsx
@@ -657,10 +657,8 @@ ${demographicSummary || '  - No disponible'}
     };
 
     const handleLogout = () => {
-        Logger.info(`User logout: ${currentUser?.username}`);
-        setIsLoggedIn(false);
-        setCurrentUser(null);
-        dbTyped.saveLoggedInUser(null);
+        Logger.info(`User logout attempted: ${currentUser?.username}`);
+        // Login is disabled, so logout simply returns to the main view
         setMainView('creative_analysis');
     };
 
@@ -704,10 +702,6 @@ ${demographicSummary || '  - No disponible'}
         )
     }
 
-    if (!isLoggedIn) {
-        return <LoginView onLogin={handleLogin} />;
-    }
-    
     return renderMainContent();
 };
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This contains everything you need to run your app locally.
    If the PostgreSQL server is unreachable, the app falls back to local storage automatically.
 
 4. The app automatically signs in with the first user (default `Admin`/`Admin`).
+5. If the SQL connection fails you can update the credentials from the **Conexión a SQL** screen located in the **Control Panel**.
 
 ## Reset Data
 

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,7 +5,7 @@ import { APP_VERSION, APP_BUILD } from '../version';
 interface NavbarProps {
     currentView: AppView;
     onNavigate: (view: AppView) => void;
-    currentUser: User;
+    currentUser: User | null;
     onLogout: () => void;
 }
 
@@ -26,13 +26,22 @@ export const Navbar: React.FC<NavbarProps> = ({ currentView, onNavigate, current
         { view: 'settings', label: 'Configuración', adminOnly: false },
     ];
 
+    if (!currentUser) {
+        return (
+            <nav className="bg-brand-surface p-4 rounded-lg shadow-md mb-8 flex justify-between items-center">
+                <span className="text-brand-text font-bold">Mi Aplicación</span>
+                <span className="text-sm text-brand-text-secondary">Cargando...</span>
+            </nav>
+        );
+    }
+
     return (
         <nav className="bg-brand-surface p-4 rounded-lg shadow-md mb-8 flex flex-col sm:flex-row justify-between items-center gap-4">
             <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-6">
                 {navItems.map(item => {
                     if (item.adminOnly && currentUser.role !== 'admin') return null;
                     return (
-                        <button 
+                        <button
                             key={item.view}
                             onClick={() => onNavigate(item.view)}
                             className={`font-semibold transition-colors ${currentView === item.view ? 'text-brand-primary' : 'text-brand-text-secondary hover:text-brand-text'}`}

--- a/server.js
+++ b/server.js
@@ -76,10 +76,10 @@ async function connectToDb(config) {
 }
 
 await connectToDb({
-  host: process.env.DB_HOST || 'Pulseweb.com.ar',
-  database: process.env.DB_NAME || 'dbzonjl9ktp0wu',
-  user: process.env.DB_USER || 'uizkbuhryctw3',
-  password: process.env.DB_PASS || 'Cataclismoss'
+  host: process.env.DB_HOST || 'localhost',
+  database: process.env.DB_NAME || 'postgres',
+  user: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASS || ''
 });
 
 app.get('/api/status', (req, res) => {

--- a/version.ts
+++ b/version.ts
@@ -1,6 +1,6 @@
 export const APP_VERSION = '0.0.1';
 
 
-export const APP_BUILD = 6;
+export const APP_BUILD = 7;
 
 


### PR DESCRIPTION
## Summary
- default DB credentials target localhost
- bump build number
- show example DB settings in `.env.example`
- document how to edit DB connection from Control Panel
- handle missing logged in user for navbar

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c35eee02883329af052e89d38f589