### PR TITLE
Use uuidv4 instead of crypto.randomUUID

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { GoogleGenAI, Type } from '@google/genai';
 import { AppView, Placement, Creative, AnalysisResult, FormatGroup, Language, CreativeSet, Client, AggregatedAdPerformance, User, AllLookerData, PerformanceRecord, TrendsAnalysisResult, TrendCardData, MetaApiConfig, BitacoraReport, UploadedVideo, ImportBatch, ProcessResult } from './types';
 import { PLACEMENTS, META_ADS_GUIDELINES } from './constants';
@@ -325,7 +326,7 @@ const App: React.FC = () => {
                 if (usersList.length === 0) {
                     Logger.warn('No users found in DB. Creating default Admin user.');
                     const defaultAdmin: User = {
-                        id: crypto.randomUUID(),
+                        id: uuidv4(),
                         username: 'Admin',
                         password: 'Admin',
                         role: 'admin'
@@ -622,7 +623,7 @@ ${demographicSummary || '  - No disponible'}
                         undoData: { type: 'meta', keys: undoKeys, clientId: processedClient.id } 
                     };
                     const history = await dbTyped.getImportHistory();
-                    await dbTyped.saveImportHistory([{ ...newBatch, id: crypto.randomUUID(), timestamp: new Date().toISOString(), fileHash: `api_sync_${Date.now()}` }, ...history]);
+                    await dbTyped.saveImportHistory([{ ...newBatch, id: uuidv4(), timestamp: new Date().toISOString(), fileHash: `api_sync_${Date.now()}` }, ...history]);
                     setImportHistory(await dbTyped.getImportHistory());
                 }
             }

--- a/components/ClientFormModal.tsx
+++ b/components/ClientFormModal.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { Client, User } from '../types';
 import { Modal } from './Modal';
 
@@ -65,7 +66,7 @@ export const ClientFormModal: React.FC<ClientFormModalProps> = ({ isOpen, onClos
         }
         
         const clientData: Client = {
-            id: initialData?.id || crypto.randomUUID(),
+            id: initialData?.id || uuidv4(),
             name: name.trim(),
             logo: logoUrl,
             currency: currency.trim().toUpperCase(),

--- a/components/ImportView.tsx
+++ b/components/ImportView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { Client, PerformanceRecord, AllLookerData, BitacoraReport, ImportBatch, MetaApiConfig, User, LookerProcessResult, ProcessResult } from '../types';
 import { NewClientsModal } from './NewClientsModal';
 import { dbTyped } from '../database';
@@ -80,7 +81,7 @@ export const ImportView: React.FC<ImportViewProps> = ({ clients, setClients, loo
     }, []);
 
     const addImportToHistory = async (batch: Omit<ImportBatch, 'id' | 'timestamp'>) => {
-        const newBatch: ImportBatch = { ...batch, id: crypto.randomUUID(), timestamp: new Date().toISOString() };
+        const newBatch: ImportBatch = { ...batch, id: uuidv4(), timestamp: new Date().toISOString() };
         setImportHistory(prev => [newBatch, ...prev]);
         await dbTyped.saveImportHistory([newBatch, ...importHistory]);
     };
@@ -260,7 +261,7 @@ export const ImportView: React.FC<ImportViewProps> = ({ clients, setClients, loo
             }
 
             const parsedReport = parseBitacoraReport(pendingTxtData.content);
-            const reportId = crypto.randomUUID();
+            const reportId = uuidv4();
             const finalReport: BitacoraReport = { ...parsedReport, id: reportId, clientId, fileName: pendingTxtData.file.name, importDate: new Date().toISOString() };
             
             setBitacoraReports([...bitacoraReports, finalReport]);
@@ -284,7 +285,7 @@ export const ImportView: React.FC<ImportViewProps> = ({ clients, setClients, loo
 
     const handleCreateNewClients = async (accountsToCreate: string[]) => {
         const newClients: Client[] = accountsToCreate.map(accountName => ({
-            id: crypto.randomUUID(),
+            id: uuidv4(),
             name: accountName,
             logo: `https://avatar.vercel.sh/${encodeURIComponent(accountName)}.png?text=${encodeURIComponent(accountName.charAt(0))}`,
             currency: 'EUR', // Default currency

--- a/components/UserFormModal.tsx
+++ b/components/UserFormModal.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { User } from '../types';
 import { Modal } from './Modal';
 
@@ -38,7 +39,7 @@ export const UserFormModal: React.FC<UserFormModalProps> = ({ isOpen, onClose, o
         }
 
         const userData: User = {
-            id: initialData?.id || crypto.randomUUID(),
+            id: initialData?.id || uuidv4(),
             username: username.trim(),
             password: password.trim() || initialData!.password, // Use new password if provided, otherwise keep old
             role: role,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "pg": "^8.11.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
## Summary
- replace browser-only `crypto.randomUUID()` with `uuid` fallback so the app works on non-secure contexts
- import `uuid` helpers in affected components
- declare `uuid` dependency

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688c42a43e1c8332915b8a2abd0bfada